### PR TITLE
Update documentation for Linux

### DIFF
--- a/Linux/README.md
+++ b/Linux/README.md
@@ -18,8 +18,8 @@
 ```javascript
 |-- idrac.sh
 |-- avctKVM.jar (idrac.sh downloads this file)
-|-- JRE
-    |-- (A lot of files under her)
+|-- jre
+    |-- (A lot of files under here)
 ```
 
 ---


### PR DESCRIPTION
* The folder should be called `jre` not `JRE`
* Fix typo